### PR TITLE
Feature/better hover detection

### DIFF
--- a/Assets/Scripts/model/core/MMesh.cs
+++ b/Assets/Scripts/model/core/MMesh.cs
@@ -192,7 +192,7 @@ namespace com.google.apps.peltzer.client.model.core
               verticesCloned,
               facesCloned,
               bounds,
-			  localBounds,
+              localBounds,
               reverseTableCloned,
               groupId,
               remixIdsCloned);
@@ -227,7 +227,7 @@ namespace com.google.apps.peltzer.client.model.core
               new Dictionary<int, Vertex>(verticesById),
               facesCloned,
               bounds,
-			  localBounds,
+              localBounds,
               new Dictionary<int, HashSet<int>>(reverseTable),
               newGroupId,
               remixIds == null ? null : new HashSet<string>(remixIds));
@@ -484,7 +484,7 @@ namespace com.google.apps.peltzer.client.model.core
             foreach (Vertex vert in verticesById.Values)
             {
                 Vector3 loc = MeshCoordsToModelCoords(vert.loc);
-				Vector3 locL = vert.loc;
+                Vector3 locL = vert.loc;
                 minX = Mathf.Min(minX, loc.x);
                 minY = Mathf.Min(minY, loc.y);
                 minZ = Mathf.Min(minZ, loc.z);

--- a/Assets/Scripts/model/core/SpatialIndex.cs
+++ b/Assets/Scripts/model/core/SpatialIndex.cs
@@ -80,8 +80,8 @@ namespace com.google.apps.peltzer.client.model.core
         private Dictionary<FaceKey, FaceInfo> faceInfo;
         private Dictionary<EdgeKey, EdgeInfo> edgeInfo;
 
-		private Dictionary<int,Matrix4x4> worldToLocalMatrices;
-        private Dictionary<int,Bounds> meshBoundsLocal;
+        private Dictionary<int, Matrix4x4> worldToLocalMatrices;
+        private Dictionary<int, Bounds> meshBoundsLocal;
 
         // A reference to the model, which is the single point of truth as to whether an item exists, despite the fact
         // that this spatial index contains collections of meshes and other items.
@@ -118,8 +118,8 @@ namespace com.google.apps.peltzer.client.model.core
 
             faceInfo = new Dictionary<FaceKey, FaceInfo>();
             edgeInfo = new Dictionary<EdgeKey, EdgeInfo>();
-			
-			worldToLocalMatrices = new Dictionary<int, Matrix4x4>();
+
+            worldToLocalMatrices = new Dictionary<int, Matrix4x4>();
             meshBoundsLocal = new Dictionary<int, Bounds>();
         }
 
@@ -180,10 +180,10 @@ namespace com.google.apps.peltzer.client.model.core
             {
                 meshBounds.Remove(mesh.id);
             }
-			if( worldToLocalMatrices.ContainsKey(mesh.id) )
-			{
-				worldToLocalMatrices.Remove(mesh.id);
-			}
+            if (worldToLocalMatrices.ContainsKey(mesh.id))
+            {
+                worldToLocalMatrices.Remove(mesh.id);
+            }
             if (meshBoundsLocal.ContainsKey(mesh.id))
             {
                 meshBoundsLocal.Remove(mesh.id);
@@ -263,7 +263,7 @@ namespace com.google.apps.peltzer.client.model.core
         public bool FindNearestMeshTo(Vector3 point, float radius, out int? nearestMesh,
           bool ignoreHiddenMeshes = false)
         {
-			Vector4 point4 = new Vector4(point.x, point.y, point.z, 1); // we need this for the matrix multiplication later
+            Vector4 point4 = new Vector4(point.x, point.y, point.z, 1); // we need this for the matrix multiplication later
             Bounds searchBounds = new Bounds(point, Vector3.one * radius * 2);
             nearestMesh = null;
             HashSet<int> meshIds;
@@ -293,15 +293,15 @@ namespace com.google.apps.peltzer.client.model.core
                             continue;
                         }
 
-						// we've probed the world-aligned bounds, but meshes can be rotated. So we check now
-						// if the point lies within the rotated and offset bounds.
-						Bounds localBounds = meshBoundsLocal[meshId];
-						Vector3 localPoint = worldToLocalMatrices[meshId] *point4;
-						if( !localBounds.Contains(localPoint) )
-						{
-							continue;
-						}
-						
+                        // we've probed the world-aligned bounds, but meshes can be rotated. So we check now
+                        // if the point lies within the rotated and offset bounds.
+                        Bounds localBounds = meshBoundsLocal[meshId];
+                        Vector3 localPoint = worldToLocalMatrices[meshId] * point4;
+                        if (!localBounds.Contains(localPoint))
+                        {
+                            continue;
+                        }
+
 
                         float distanceToPoint = Vector3.Distance(bounds.center, point);
                         if (distanceToPoint < minDistance)
@@ -873,10 +873,10 @@ namespace com.google.apps.peltzer.client.model.core
             meshes.Add(mesh.id, mesh.bounds);
             meshBounds.Add(mesh.id, mesh.bounds);
 
-			worldToLocalMatrices.Add(mesh.id,Matrix4x4.TRS(mesh.offset,mesh.rotation,Vector3.one).inverse);
+            worldToLocalMatrices.Add(mesh.id, Matrix4x4.TRS(mesh.offset, mesh.rotation, Vector3.one).inverse);
             meshBoundsLocal.Add(mesh.id, mesh.localBounds);
-            
-			foreach (KeyValuePair<FaceKey, FaceInfo> pair in faceInfos)
+
+            foreach (KeyValuePair<FaceKey, FaceInfo> pair in faceInfos)
             {
                 faces.Add(pair.Key, pair.Value.bounds);
                 faceInfo[pair.Key] = pair.Value;

--- a/Assets/Scripts/model/core/SpatialIndex.cs
+++ b/Assets/Scripts/model/core/SpatialIndex.cs
@@ -79,9 +79,8 @@ namespace com.google.apps.peltzer.client.model.core
         private CollisionSystem<int> meshBounds;
         private Dictionary<FaceKey, FaceInfo> faceInfo;
         private Dictionary<EdgeKey, EdgeInfo> edgeInfo;
+
 		private Dictionary<int,Matrix4x4> worldToLocalMatrices;
-		private Dictionary<int,Vector3> offsets;
-		private Dictionary<int,Quaternion> rotations;
         private Dictionary<int,Bounds> meshBoundsLocal;
 
         // A reference to the model, which is the single point of truth as to whether an item exists, despite the fact
@@ -119,8 +118,7 @@ namespace com.google.apps.peltzer.client.model.core
 
             faceInfo = new Dictionary<FaceKey, FaceInfo>();
             edgeInfo = new Dictionary<EdgeKey, EdgeInfo>();
-			offsets = new Dictionary<int, Vector3>();
-			rotations = new Dictionary<int, Quaternion>();
+			
 			worldToLocalMatrices = new Dictionary<int, Matrix4x4>();
             meshBoundsLocal = new Dictionary<int, Bounds>();
         }
@@ -186,14 +184,6 @@ namespace com.google.apps.peltzer.client.model.core
 			{
 				worldToLocalMatrices.Remove(mesh.id);
 			}
-            if (offsets.ContainsKey(mesh.id))
-            {
-                offsets.Remove(mesh.id);
-            }
-            if (rotations.ContainsKey(mesh.id))
-            {
-                rotations.Remove(mesh.id);
-            }
             if (meshBoundsLocal.ContainsKey(mesh.id))
             {
                 meshBoundsLocal.Remove(mesh.id);
@@ -306,8 +296,6 @@ namespace com.google.apps.peltzer.client.model.core
 						// we've probed the world-aligned bounds, but meshes can be rotated. So we check now
 						// if the point lies within the rotated and offset bounds.
 						Bounds localBounds = meshBoundsLocal[meshId];
-						// Vector3 localPoint = Matrix4x4.TRS(offsets[meshId],rotations[meshId],Vector3.one).inverse *point4;
-						// Vector3 localPoint = worldToLocalMatrices[meshId] *new Vector4(point.x, point.y, point.z, 1);
 						Vector3 localPoint = worldToLocalMatrices[meshId] *point4;
 						if( !localBounds.Contains(localPoint) )
 						{
@@ -884,11 +872,11 @@ namespace com.google.apps.peltzer.client.model.core
             }
             meshes.Add(mesh.id, mesh.bounds);
             meshBounds.Add(mesh.id, mesh.bounds);
-            meshBoundsLocal.Add(mesh.id, mesh.localBounds);
+
 			worldToLocalMatrices.Add(mesh.id,Matrix4x4.TRS(mesh.offset,mesh.rotation,Vector3.one).inverse);
-			offsets.Add(mesh.id, mesh.offset);
-			rotations.Add(mesh.id, mesh.rotation);
-            foreach (KeyValuePair<FaceKey, FaceInfo> pair in faceInfos)
+            meshBoundsLocal.Add(mesh.id, mesh.localBounds);
+            
+			foreach (KeyValuePair<FaceKey, FaceInfo> pair in faceInfos)
             {
                 faces.Add(pair.Key, pair.Value.bounds);
                 faceInfo[pair.Key] = pair.Value;


### PR DESCRIPTION
Ok, something more serious this time.

The basic hover detection, when using the hand tool, didn't work very nicely with rotated meshes, as it only checked world-aligned bounds. So if you had an elongated object rotated at for example 45 degree, like a slanted roof, it became very awkward to work under that roof, as you keep selecting the roof itself when the hand tool enters the world-aligned bounds.

I've added an extra check, after the world-aligned bounds is triggered, that checks the sample point against the local bounds inside the mesh, rotated and offset, via matrix multiplication. To make this work, I had MMesh keep track of its local bounds, and SpatialIndex chache the worldToLocal matrix of the mesh, and the local bounds of the mesh.

It is probably a _little_ less performant, but doesn't seem too bad at all when I test it with some production scenes here. Hover selection is now much more precise!

NB: meshes that are modelled diagonally _within their reference frame_ will still suffer the same awkwardness as before, but this is not to be helped, unless we want to investigate if we can have some auto-aligning local bounds system for these cases. Which seems overkill.

Hope I got the formatting right now as well!