### PR TITLE
Fix shadows and modify tool on Quest

### DIFF
--- a/Assets/Rendering/Lighting.cs
+++ b/Assets/Rendering/Lighting.cs
@@ -234,18 +234,23 @@ public class Lighting : MonoBehaviour
 
     void OnPostRender()
     {
-
+        if (blurIterations == 0)
+        {
+            Graphics.Blit(shadowTexture, blurShadowTexture, blurMat, 0);
+            return;
+        }
+        
         int res = shadowResolution;
         if (downsample)
         {
             res = shadowResolution / 2;
         }
-
+        
         RenderTexture rtQuarter =
-          RenderTexture.GetTemporary(res, res, 0, renderTextureFormat, RenderTextureReadWrite.Linear);
+            RenderTexture.GetTemporary(res, res, 0, renderTextureFormat, RenderTextureReadWrite.Linear);
         RenderTexture rtQuarterB =
-          RenderTexture.GetTemporary(res, res, 0, renderTextureFormat, RenderTextureReadWrite.Linear);
-
+            RenderTexture.GetTemporary(res, res, 0, renderTextureFormat, RenderTextureReadWrite.Linear);
+        
         Graphics.Blit(shadowTexture, rtQuarter, blurMat, 0);
 
         for (int i = 0; i < blurIterations; i++)
@@ -254,7 +259,7 @@ public class Lighting : MonoBehaviour
             Graphics.Blit(rtQuarterB, rtQuarter, blurMat, 4);
         }
 
-        Graphics.Blit(rtQuarter, blurShadowTexture);
+        Graphics.Blit(rtQuarter, blurShadowTexture, blurMat, 5);
 
         rtQuarter.DiscardContents();
         RenderTexture.ReleaseTemporary(rtQuarter);

--- a/Assets/Rendering/PenumbraShadows.cginc
+++ b/Assets/Rendering/PenumbraShadows.cginc
@@ -1,7 +1,7 @@
 ﻿float4x4 _ShadowMatrix;
-sampler2D _ShadowTexture;
+sampler2D_float _ShadowTexture;
 sampler2D _ShadowPointTexture;
-sampler2D _ShadowBlurTexture;
+sampler2D_float _ShadowBlurTexture;
 float3 _LightColor;
 float4 _LightDirection;
 float4 _LightPosition;

--- a/Assets/XR/Settings/OpenXR Package Settings.asset
+++ b/Assets/XR/Settings/OpenXR Package Settings.asset
@@ -357,7 +357,7 @@ MonoBehaviour:
   - {fileID: -5196133658107764757}
   m_renderMode: 0
   m_depthSubmissionMode: 1
-  m_optimizeBufferDiscards: 1
+  m_optimizeBufferDiscards: 0
   m_symmetricProjection: 0
 --- !u!114 &-1044453806702251804
 MonoBehaviour:
@@ -438,7 +438,7 @@ MonoBehaviour:
   symmetricProjection: 0
   foveatedRenderingApi: 0
   systemSplashScreen: {fileID: 0}
-  optimizeBufferDiscards: 1
+  optimizeBufferDiscards: 0
   lateLatchingMode: 0
   lateLatchingDebug: 0
 --- !u!114 &11400000


### PR DESCRIPTION
Regarding shadows:
Shadows were not showing correctly on Quest because of precision issues when using Vulkan.

Regarding the modify tool:
GrabPass in shaders for overlaying vertex and edge highlights (when using the modify tool) broke rendering on Quest.
Fix: disable optimize buffer discards in Android settings for Quest