### PR TITLE
Replace pre-commit with prek (and update pre-commit-config)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,27 +13,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6.1.0
-        with:
-          python-version: '3.12'
       - uses: actions/setup-dotnet@v5.0.1
         with:
           dotnet-version: '8.0.x'
-      - name: Install pre-commit
-        run: python -m pip install pre-commit
+      - uses: actions/setup-go@v6  # One of our hooks (gitleaks) needs a newer Go version than we get from the runner
+        with:
+          go-version: '>=1.25.4'
+          cache: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: "false"
+      - name: Install prek
+        run: uv tool install prek
         shell: bash
       - name: Cache pre-commit environments
         uses: actions/cache@v5
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Setup pre-commit environments
-        run: pre-commit run
-      - name: Run pre-commit dotnet-format, with retries
+          path: ~/.cache/prek
+          key: prek|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Setup prek environments (separate step for timing purposes)
+        run: prek run
+      - name: Run prek dotnet-format, with retries
         uses: Wandalen/wretry.action@v3
         with:
-          command: pre-commit run dotnet-format --show-diff-on-failure --color=always --all-files || { git checkout -- . ; exit 1 ; }  # In case dotnet-format fails, reset the changes it made. This way, we can differentiate between a NuGet failure and a real formatting issue
-      - name: Remove dotnet-format from the list of pre-commit jobs to run (since we already ran it)
+          command: prek run dotnet-format --show-diff-on-failure --color=always --all-files || { git checkout -- . ; exit 1 ; }  # In case dotnet-format fails, reset the changes it made. This way, we can differentiate between a NuGet failure and a real formatting issue
+      - name: Remove dotnet-format from the list of prek jobs to run (since we already ran it)
         run: yq eval 'del(.repos[] | select(.hooks[].id == "dotnet-format"))' -i .pre-commit-config.yaml
       - name: Run the rest of pre-commit
-        run: pre-commit run --show-diff-on-failure --color=always --all-files
+        run: prek run --show-diff-on-failure --color=always --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,17 +4,20 @@ repos:
     rev: v1.37.1
     hooks:
       - id: yamllint
+        priority: 10
   - repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:
       - id: black
         files: ^Support/
         language_version: python3
+        priority: 1
   - repo: https://github.com/pycqa/flake8
     rev: 7.3.0
     hooks:
       - id: flake8
         files: ^Support/
+        priority: 10
   - repo: https://github.com/PyCQA/pylint.git
     rev: v3.3.7
     hooks:
@@ -27,6 +30,7 @@ repos:
         args:
           - --load-plugins=pylint.extensions.redefined_variable_type,pylint.extensions.bad_builtin
           - --disable=import-error
+        priority: 10
   - repo: https://github.com/google/yamlfmt
     rev: v0.17.2
     hooks:
@@ -34,6 +38,7 @@ repos:
         args:
           - -conf
           - .yamlfmt
+        priority: 1
   - repo: local
     hooks:
       # Use dotnet format already installed on your machine
@@ -46,7 +51,9 @@ repos:
         args:
           - --folder
           - --include
+        priority: 10
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.27.2
     hooks:
       - id: gitleaks
+        priority: 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.37.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         priority: 10
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
       - id: black
         files: ^Support/
@@ -19,7 +19,7 @@ repos:
         files: ^Support/
         priority: 10
   - repo: https://github.com/PyCQA/pylint.git
-    rev: v3.3.7
+    rev: v4.0.4
     hooks:
       - id: pylint
         name: pylint
@@ -32,7 +32,7 @@ repos:
           - --disable=import-error
         priority: 10
   - repo: https://github.com/google/yamlfmt
-    rev: v0.17.2
+    rev: v0.21.0
     hooks:
       - id: yamlfmt
         args:
@@ -53,7 +53,7 @@ repos:
           - --include
         priority: 10
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.27.2
+    rev: v8.30.0
     hooks:
       - id: gitleaks
         priority: 10


### PR DESCRIPTION
Technically, no user action is required here, as prek is a drop in replacement for pre-commit. However, to switch locally from `pre-commit` to `prek`, the following steps are required:

1. Install prek (https://prek.j178.dev/installation/). 
2. Within the repo, update the git hook using `prek install -f`